### PR TITLE
Catch 'do' errors, dump config for debugging

### DIFF
--- a/lib/Ndn/Environment/Config.pm
+++ b/lib/Ndn/Environment/Config.pm
@@ -7,13 +7,18 @@ use warnings;
 use parent 'Exporter';
 
 use Try::Tiny;
+        use Data::Dumper;
 
 our @EXPORT = qw/config/;
 
 sub config {
-
     state $CONFIG = try {
-        do './env_config.pm';
+        my $content = do './env_config.pm';
+        die "No config: " . ($@ || $!) unless $content;
+
+        print Dumper($content);
+
+        return $content;
     }
     catch {
         die "Could not load ./env_config.pm: $_";


### PR DESCRIPTION
This catches 'do' errors, and also restores the config dump. We may change the config dump to be enabled via a command line flag later, but for now we need it for jenkins.