### PR TITLE
dpkg-deb strikes again: ${shlibs:Depends}

### DIFF
--- a/lib/Ndn/Environment/Builder/Package.pm
+++ b/lib/Ndn/Environment/Builder/Package.pm
@@ -119,5 +119,5 @@ Section:      devel
 Maintainer:   [% maint %]
 Architecture: [% arch %]
 Version:      [% ver  %]
-Depends:      ${shlibs:Depends}, [% deps %]
+Depends:      [% deps %]
 Description:  [% desc %]

--- a/t/builder/package/templating.t
+++ b/t/builder/package/templating.t
@@ -41,5 +41,5 @@ Section:      devel
 Maintainer:   Captain Jack Harkness
 Architecture: here
 Version:      there
-Depends:      ${shlibs:Depends}, stuff, more-stuff
+Depends:      stuff, more-stuff
 Description:  yaaaaaay


### PR DESCRIPTION
dpkg-deb appears to be akin to git "plumbing" commands.  We'll revisit/revert
this when/if we switch to debuild or the like.