### PR TITLE
fix -- missing description in debian/control

### DIFF
--- a/lib/Ndn/Environment/Builder/Package.pm
+++ b/lib/Ndn/Environment/Builder/Package.pm
@@ -52,6 +52,7 @@ sub steps {
             arch  => $arch,
             ver   => $ver,
             deps  => $deps,
+            desc  => $desc,
         });
     };
 


### PR DESCRIPTION
...*le sigh*.  This looks to have been inadvertently omitted during the 
conversion to a templated system.