### PR TITLE
add tests for the package builder

### DIFF
--- a/lib/Ndn/Environment.pm
+++ b/lib/Ndn/Environment.pm
@@ -10,6 +10,7 @@ use Ndn::Environment::Config;
 
 use File::Temp qw/tempdir/;
 use Cwd qw/getcwd/;
+use Path::Tiny;
 use Module::Pluggable
     sub_name    => 'load_plugins',
     search_path => 'Ndn::Environment::Builder',
@@ -111,19 +112,9 @@ sub dest {
     return $out;
 }
 
-sub perl {
-    my $self = shift;
-    my $dest = $self->dest;
-    my $bin_dir = $self->dest . '/perl/bin';
-    return "$bin_dir/perl";
-}
-
-sub cpanm {
-    my $self = shift;
-    my $dest = $self->dest;
-    my $bin_dir = $self->dest . '/perl/bin';
-    return "$bin_dir/cpanm";
-}
+accessor bin_dir => sub { path shift->dest, qw { perl bin } };
+accessor perl    => sub { path shift->bin_dir, 'perl'       };
+accessor cpanm   => sub { path shift->bin_dir, 'cpanm'      };
 
 sub archname {
     my $self = shift;

--- a/lib/Ndn/Environment.pm
+++ b/lib/Ndn/Environment.pm
@@ -116,7 +116,7 @@ accessor bin_dir => sub { path shift->dest, qw { perl bin } };
 accessor perl    => sub { path shift->bin_dir, 'perl'       };
 accessor cpanm   => sub { path shift->bin_dir, 'cpanm'      };
 
-sub archname {
+accessor archname => sub {
     my $self = shift;
 
     my $perl = $self->perl;
@@ -125,7 +125,7 @@ sub archname {
     my ($archname) = `$perl -V:archname` =~ /='([^']+)'/;
 
     return $archname;
-}
+};
 
 1;
 

--- a/t/live/package.t
+++ b/t/live/package.t
@@ -1,0 +1,69 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::File;
+use Test::TempDir::Tiny;
+use Data::Section::Simple 'get_data_section';
+use File::chdir;
+use Path::Tiny;
+
+use aliased 'Ndn::Environment::Builder::Package' => 'Builder';
+
+# A small test, just to make sure we actually install cpanm where we expect
+# it.
+#
+# Note (and FIXME!): we're not yet using App::Cmd::Tester as we haven't
+# finished decoupling our config and other bits from the builders/commands
+# yet.  This is still largely a (usable) work in progress.
+
+
+my $test_target = tempdir;
+my $root = path $test_target, 'root';
+
+# set up our config file
+$root->mkpath;
+path($root, 'env_config.pm')->spew(get_data_section('env_config.pm'));
+
+{
+    local $CWD = "$root"; # 't/live/package';
+
+    my $pkg_dir = path $test_target, 'package';
+    my $pkged_perl = path $pkg_dir, $test_target, qw{ build perl bin perl };
+
+    Builder->NDN_ENV->temp($test_target);
+    Builder->NDN_ENV->base_dir($test_target);
+    Builder->NDN_ENV->build_dir('build');
+    Builder->NDN_ENV->archname('x86_64');
+
+    # fake out our "is perl built?" checks
+    my $bin_dir = Builder->NDN_ENV->bin_dir;
+    $bin_dir->mkpath;
+    path($bin_dir, 'perl')->touch->spew('hi there!');
+
+    my $builder = Builder->new;
+    isa_ok $builder => Builder;
+
+    $builder->run;
+
+    my $installed_cpanm = "$test_target/build/perl/bin/cpanm";
+    my $debian_dir = path $test_target, qw{ package DEBIAN };
+    file_exists_ok "$debian_dir/control";
+    file_exists_ok $pkged_perl;
+    file_exists_ok "$root/ndn-environment-42.deb";
+}
+
+done_testing;
+
+__DATA__
+
+@@ env_config.pm
+{
+    testing => 1,
+    package => {
+    
+        description => 'A nice, little package!',
+        depends     => 'libxml2',
+        version     => sub { 42 },
+    },
+};

--- a/t/live/package.t
+++ b/t/live/package.t
@@ -26,11 +26,12 @@ $root->mkpath;
 path($root, 'env_config.pm')->spew(get_data_section('env_config.pm'));
 
 {
-    local $CWD = "$root"; # 't/live/package';
+    local $CWD = "$root";
 
     my $pkg_dir = path $test_target, 'package';
     my $pkged_perl = path $pkg_dir, $test_target, qw{ build perl bin perl };
 
+    ### override our paths...
     Builder->NDN_ENV->temp($test_target);
     Builder->NDN_ENV->base_dir($test_target);
     Builder->NDN_ENV->build_dir('build');
@@ -46,7 +47,6 @@ path($root, 'env_config.pm')->spew(get_data_section('env_config.pm'));
 
     $builder->run;
 
-    my $installed_cpanm = "$test_target/build/perl/bin/cpanm";
     my $debian_dir = path $test_target, qw{ package DEBIAN };
     file_exists_ok "$debian_dir/control";
     file_exists_ok $pkged_perl;
@@ -61,7 +61,7 @@ __DATA__
 {
     testing => 1,
     package => {
-    
+
         description => 'A nice, little package!',
         depends     => 'libxml2',
         version     => sub { 42 },


### PR DESCRIPTION
A basic, rudimentary test that runs through a dummy packaging of one file.

...but that's more than enough to validate that our control files are being
created in the right places, etc!  This is quick, valid, and totally bypasses
building perl or anything else in order to test this builder.

With confidence!

With gusto!

We test these things not because they are easy, but because...  Vigah!