### PR TITLE
Use dpkg scriptlets to control a 'current' symlink

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -26,6 +26,7 @@ my $build = Module::Build->new(
     },
     build_requires => {
         'aliased'             => 0,
+        'Devel::CheckBin'     => '0.02',
         'File::chdir'         => '0.1010',
         'Test::File'          => '1.41',
         'Test::Simple'        => '0.88',

--- a/lib/Ndn/Environment.pm
+++ b/lib/Ndn/Environment.pm
@@ -85,24 +85,11 @@ sub builder {
     return $self->builder_list->{$builder};
 }
 
-accessor base_dir => sub {
-    my $self = shift;
-    return unless config;
-    my $base = $ENV{ENV_DEST} || config->{dest_dir} || "/opt/penv";
-    return $base;
-};
-
-accessor build_dir => sub {
-    my $self = shift;
-    my $build = $ENV{ENV_BUILD} || config->{build}->();
-    return $build;
-};
-
 sub dest {
     my $self = shift;
     return unless config;
 
-    state $out;
+    my $out;
     unless($out) {
         my $base = $self->base_dir;
         my $build = $self->build_dir;
@@ -112,9 +99,11 @@ sub dest {
     return $out;
 }
 
-accessor bin_dir => sub { path shift->dest, qw { perl bin } };
-accessor perl    => sub { path shift->bin_dir, 'perl'       };
-accessor cpanm   => sub { path shift->bin_dir, 'cpanm'      };
+accessor base_dir  => sub { $ENV{ENV_DEST} || config->{dest_dir} || '/opt/penv' };
+accessor build_dir => sub { $ENV{ENV_BUILD} || config->{build}->()              };
+accessor bin_dir   => sub { path shift->dest, qw { perl bin }                   };
+accessor perl      => sub { path shift->bin_dir, 'perl'                         };
+accessor cpanm     => sub { path shift->bin_dir, 'cpanm'                        };
 
 accessor archname => sub {
     my $self = shift;

--- a/lib/Ndn/Environment/Builder/Package.pm
+++ b/lib/Ndn/Environment/Builder/Package.pm
@@ -95,6 +95,8 @@ sub _debian_file {
 
 1;
 
+__DATA__
+
 =head1 NAME
 
 Ndn::Environment::Builder::Package - Build the environment into a package
@@ -110,8 +112,6 @@ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 FOR A PARTICULAR PURPOSE. See the license for more details.
 
 =cut
-
-__DATA__
 
 @@ debian/control
 Package:      [% name %]

--- a/lib/Ndn/Environment/Builder/Package.pm
+++ b/lib/Ndn/Environment/Builder/Package.pm
@@ -185,6 +185,7 @@ if [ "$1" = "upgrade" ]; then
 
     # this is suffient to ensure the symlink is pointing to the right place
     echo "Updating symlink to: $_new_target"
+    rm [% current_symlink %]
     ln -sf "$_new_target" [% current_symlink %]
 fi
 

--- a/lib/Ndn/Environment/Builder/Package.pm
+++ b/lib/Ndn/Environment/Builder/Package.pm
@@ -56,26 +56,45 @@ sub steps {
         });
     };
 
+    my $_build_scriptlet = sub {
+        $self->_debian_file($debian_dir => $_[0], {
+            -mode           => 0755,
+            our_pkg_dir     => path($dest),
+            our_prefix      => $base_dir,
+            current_symlink => path($base_dir, 'current'),
+        });
+    };
+
     return (
         sub {
             return unless config->{package}->{prebuild};
             config->{package}->{prebuild}->();
         },
-        sub { $debian_dir->mkpath },
-        "mkdir -p $pkg_dir/$base_dir",
-        "mkdir -p $pkg_dir/$dest",
+        sub {
+            $debian_dir->mkpath;
+            path($pkg_dir, $base_dir)->mkpath;
+            path($pkg_dir, $dest)->mkpath;
+        },
         "rsync -avP '$dest' '$pkg_dir/$base_dir/'",
         "rm -rf '$dest'",
-        sub { $_build_control->() },
+        $_build_control,
+        sub { $_build_scriptlet->('postinst') },
+        sub { $_build_scriptlet->('postrm')   },
+        sub { $_build_scriptlet->('prerm')    },
 
         # FIXME note, this should probably be debuild
         "dpkg-deb -z8 -Zgzip --build '$pkg_dir' '$name-$ver.deb'"
     );
 }
 
+# In our templates, we currently support the following keys:
+#
+# * our_pkg_dir: e.g. /opt/<version>
+# * current_symlink: what our current symlink should be named
+
 sub _debian_file {
     my ($self, $debian_dir, $target_filename, $vars) = @_;
-
+    my $mode = delete $vars->{'-mode'} || 0644;
 
     ### get our template, and generate: "debian/$target_filename"
     my $file     = path $debian_dir, $target_filename;
@@ -89,6 +108,7 @@ sub _debian_file {
 
     ### write: "$file"
     $file->spew($output);
+    $file->chmod($mode);
 
     return;
 }
@@ -100,6 +120,28 @@ __DATA__
 =head1 NAME
 
 Ndn::Environment::Builder::Package - Build the environment into a package
+
+=head1 SCRIPTLETS
+
+We use a number of scriptlets to help control the upgrade process and maintain
+symlink to a usable environment perl through the update.
+
+At the minimum, we need to handle the following scenariaos:
+
+=head2 install
+
+The symlink should be created after the package files are installed.
+
+=head2 upgrade
+
+To minimize the amount of time we're without a usable environment perl during
+upgrades, our "current" symlink needs to be moved from pointing at the old
+perl to the new one after the new package's files are unpacked but before the
+old package's files are deleted.
+
+=head2 remove
+
+The symlink should be removed after package files are removed.
 
 =head1 COPYRIGHT
 
@@ -122,3 +164,65 @@ Architecture: [% arch %]
 Version:      [% ver  %]
 Depends:      [% deps %]
 Description:  [% desc %]
+@@ debian/postrm
+#!/bin/sh
+
+# A post-remove scriptlet, to update our current symlink.
+#
+# When upgrading to a newer version, the version of this script in the old
+# (aka installed) package is invoked with "upgrade" after the new version's
+# files are unpacked but *before* the old files are removed.
+#
+# See also: https://wiki.debian.org/MaintainerScripts
+
+set -e
+
+if [ "$1" = "upgrade" ]; then
+
+    # strip off the OS/level part
+    _ver=`echo $2 | sed -e 's/\+.*//'`
+    _new_target="[% our_prefix %]/$_ver"
+
+    # this is suffient to ensure the symlink is pointing to the right place
+    echo "Updating symlink to: $_new_target"
+    ln -sf "$_new_target" [% current_symlink %]
+fi
+
+@@ debian/postinst
+#!/bin/sh
+
+# a post-install scriptlet, to create our current symlink
+#
+# When installing this package on a system without a prior version installed,
+# create our current symlink.
+#
+# See also: https://wiki.debian.org/MaintainerScripts
+
+set -e
+
+if [ "$1" = "configure" ]; then
+
+    # initial package installation
+    echo "Creating symlink"
+    ln -sf [% our_pkg_dir %] [% current_symlink %]
+fi
+
+@@ debian/prerm
+#!/bin/sh
+
+# A pre-remove scriptlet, to remove our current symlink.
+#
+# When removing this package from the system (not upgrading), delete our
+# current symlink before removing our files.
+#
+# See also: https://wiki.debian.org/MaintainerScripts
+
+set -e
+
+if [ "$1" = "remove" ]; then
+
+    # outright package removal
+    echo "Removing symlink"
+    rm [% current_symlink %]
+fi
+

--- a/t/live/package-scriptlets.t
+++ b/t/live/package-scriptlets.t
@@ -1,0 +1,163 @@
+use strict;
+use warnings;
+use autodie;
+
+# test our scriptlets on install/upgrade/remove
+#
+# Run actual install/upgrade/remove operations with two packages we build, and
+# validate that the 'current' symlink exists/is-correct/dne properly.
+#
+# For implementation purposes -- and so as to not hose anyone's system --
+# while also allowing for real unit tests here, we take advantage of the
+# Travis CI system to do the installs on.  The Travis VM's are reset after
+# each build job, so we don't need to worry about trashing anything: it's not
+# going to exist a few seconds after the job completion in any case :)
+#
+# We implement a check to ensure we're running on Travis, as well as some
+# notes to help guide future implementation work of {fake,}chroot environments
+# to be able to run these tests locally.  (Local runs are not presently
+# implemented, however, and likely wouldn't do anyone on fubar any good
+# anyways.)
+
+use Test::More;
+use Test::File;
+use Test::TempDir::Tiny;
+use Capture::Tiny ':all';
+use Devel::CheckBin;
+use Data::Section::Simple 'get_data_section';
+use File::chdir;
+use Path::Tiny;
+
+use aliased 'Ndn::Environment::Builder::Package' => 'Builder';
+
+if ($ENV{TRAVIS_PERL_VERSION}) {
+
+    ### we're running on travis, so can install natively for tests...
+    diag 'Running on Travis; installing packages natively to test';
+}
+else {
+
+    ### not on travis! see about a chroot...
+
+    # NOTE: check for root/sudo capability here (easier to build chroots)
+
+    # if we can't do root, we need the fake* stuff
+    do { plan skip_all => "Test requires $_" unless can_run($_) }
+        for qw{ fakeroot fakechroot debootstrap };
+
+    # NOTE: build out a chroot!
+
+    # NOTE: nix this
+    #plan skip_all => 'Non-travis support not yet implemented.';
+}
+
+my $test_target = tempdir;
+my $root = path $test_target, 'root';
+
+# set up our config file
+$root->mkpath;
+path($root, 'env_config.pm')->spew(get_data_section('env_config.pm'));
+
+my ($v42, $v43);
+
+subtest 'build our packages' => sub {
+    local $CWD = "$root";
+
+    my $pkg_dir = path $test_target, 'package';
+
+    ### override our paths...
+    Builder->NDN_ENV->temp($test_target);
+    Builder->NDN_ENV->base_dir($test_target);
+    Builder->NDN_ENV->archname('x86_64');
+
+    my $builder = Builder->new;
+    isa_ok $builder => Builder;
+
+    my $_build = sub {
+
+        $pkg_dir->remove_tree;
+
+        my $build_dir = "build-$_[0]";
+        my $bin_dir = path $test_target, $build_dir, qw{ perl bin };
+        $bin_dir->mkpath;
+        my $pkged_perl = path $pkg_dir, $test_target, $build_dir, qw{ perl bin perl };
+        my $built_perl = path $bin_dir, 'perl';
+
+        # fake out our "is perl built?" checks
+        Builder->NDN_ENV->build_dir($build_dir);
+        Builder->NDN_ENV->bin_dir($bin_dir);
+        Builder->NDN_ENV->perl($built_perl);
+        $built_perl->touch->spew('hi there!');
+        $builder->run;
+        file_exists_ok $pkged_perl;
+    };
+
+    note 'first run';
+    capture_merged { $_build->(42) };
+    file_exists_ok $v42 = path "$root/ndn-environment-42.deb";
+    note '...and the second';
+    capture_merged { $_build->(43) };
+    file_exists_ok $v43 = path "$root/ndn-environment-43.deb";
+};
+
+my $build_dir = path $root, 'build';
+
+subtest 'sanity checking' => sub {
+    file_not_exists_ok $build_dir;
+    file_exists_ok $v42;
+    file_exists_ok $v43;
+};
+
+my $current_symlink = path $test_target, 'current';
+my $v42_target      = path $test_target, 'build-42';
+my $v43_target      = path $test_target, 'build-43';
+
+subtest 'validate install symlink' => sub {
+
+    diag "installing $v42";
+    system "sudo dpkg -i $v42";
+
+    file_is_symlink_ok $current_symlink;
+    symlink_target_exists_ok $current_symlink;
+    file_exists_ok $v42_target;
+    file_not_exists_ok $v43_target;
+    symlink_target_is $current_symlink, $v42_target;
+};
+
+subtest 'validate upgrade symlink' => sub {
+
+    diag "upgrading to $v43";
+    system "sudo dpkg -i $v43";
+
+    file_is_symlink_ok $current_symlink;
+    symlink_target_exists_ok $current_symlink;
+    file_not_exists_ok $v42_target;
+    file_exists_ok $v43_target;
+    symlink_target_is $current_symlink, $v43_target;
+};
+
+subtest 'validate remove symlink' => sub {
+
+    diag "removing ndn-environment";
+    system 'sudo dpkg -r ndn-environment';
+
+    file_not_exists_ok $v42_target;
+    file_not_exists_ok $v43_target;
+    file_not_exists_ok $current_symlink;
+};
+
+done_testing;
+
+__DATA__
+
+@@ env_config.pm
+my $i = 42;
+{
+    testing => 1,
+    package => {
+
+        description => 'A nice, little package!',
+        depends     => 'dpkg', # it's always there!
+        version     => sub { $i++ },
+    },
+};

--- a/t/live/package-scriptlets.t
+++ b/t/live/package-scriptlets.t
@@ -48,7 +48,7 @@ else {
     # NOTE: build out a chroot!
 
     # NOTE: nix this
-    #plan skip_all => 'Non-travis support not yet implemented.';
+    plan skip_all => 'Non-travis support not yet implemented.';
 }
 
 my $test_target = tempdir;

--- a/t/live/package.t
+++ b/t/live/package.t
@@ -47,9 +47,16 @@ path($root, 'env_config.pm')->spew(get_data_section('env_config.pm'));
 
     $builder->run;
 
+    ### check out our package files and control files...
     my $debian_dir = path $test_target, qw{ package DEBIAN };
-    file_exists_ok "$debian_dir/control";
+    my @scriptlets = map { path $debian_dir, $_ } qw{ prerm postrm postinst };
     file_exists_ok $pkged_perl;
+    file_exists_ok "$debian_dir/control";
+    file_mode_is "$debian_dir/control", 0644;
+    do { file_exists_ok $_; file_mode_is $_, 0755 }
+        for @scriptlets;
+
+    ### make sure the actual package was built...
     file_exists_ok "$root/ndn-environment-42.deb";
 }
 


### PR DESCRIPTION
...such that it always points to a usable (read: fully present, unpacked)
installation of ours during package upgrades.

Note that this is tested automagically on Travis!

This is part of PE-14.